### PR TITLE
Branch protection (fixes #4)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
-# All members of the Code for Lansing Leadership team are considered code
-# owners for all new projects. Additional individuals and teams can be added
-# on a per-project basis.
+# All members of the Code for Lansing Cityzen Maintainers team are considered
+# code owners for this project.
 
-*       @codeforlansing/leadership
+*       @codeforlansing/cityzen-maintainers


### PR DESCRIPTION
These changes resolve #4.

## Organization changes

I created a new team named `Cityzen Maintainers` as a means of managing code
ownership and administrator privileges in Cityzen projects. This and many of
the branch protection rules described below were done in accordance with the
[Best practices for protected branches](https://github.community/t5/Support-Protips/Best-practices-for-protected-branches/ba-p/10224).

## Repository settings

I made the following configuration changes to the GitHub repository.
Can you please verify these?

**Options**

1. Uncheck `Wikis`
2. Uncheck `Allow merge commits`
3. Uncheck `Allow squash merging`
4. Automatically delete head branches

**Collaborators & Teams**

1. Add `Leadership` team with `Triage` permission
2. Add `Cityzen Maintainers` team with `Admin` permission

**Branches**
1. New branch protection rule for `master`:
   - Checked `Require pull request reviews before merging`
   - Set `Required approving reviews` to `1`
   - Checked `Dismiss stale pull request approvals when new commits are pushed`
   - Checked `Require review from Code Owners`
   - Checked `Require status checks to pass before merging`
   - Checked `Require branches to be up to date before merging`
   - Checked `build` as required status check
   - Checked `Include administrators`

## File changes

I also made some file changes. Can you please review these as well?

1. Designated all members of the `Cityzen Maintainers` team as `CODEOWNERS`.

2. The VS Code ESLint extension automatically updated `settings.json` to
   upgrade our autofix setting to a new structure. It left the deprecated, old
   config in place. We can remove that after a while.