### PR TITLE
Allows running the app with `npx cityzen-server`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const { loadConfig } = require('./src/config')
 const app = require('./src/app')
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "lint": "eslint .",
     "test": "jest"
   },
+  "bin": {
+    "cityzen-server": "./index.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/codeforlansing/cityzen-server.git"


### PR DESCRIPTION
This adds a binary to the package, which can be used to launch the application. This is meant to enable https://github.com/codeforlansing/cityzen-client-vue/pull/10