### PR TITLE
Adds a simple abstraction for sending messages to users

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -35,7 +35,7 @@ async function app (config) {
 
   // Add a route to handle the `/messages` route
   const messageProvider = config.messages.provider.provider
-  app.use('/message/', await MessageProvider.mount(messageProvider, config.messages, config))
+  app.use('/messages/', await MessageProvider.mount(messageProvider, config.messages, config))
 
   return express().use(config.server.prefix, app)
 }

--- a/src/app.js
+++ b/src/app.js
@@ -3,6 +3,7 @@ const express = require('express')
 const helmet = require('helmet')
 const UserProvider = require('./users')
 const TaskProvider = require('./tasks')
+const MessageProvider = require('./messages')
 
 /**
  * Builds the application, returning an express app that can be launched or used for testing.
@@ -31,6 +32,10 @@ async function app (config) {
   // JSON array containing all the tasks that volunteers can work on.
   const taskProvider = config.tasks.provider.provider
   app.use('/tasks/', await TaskProvider.mount(taskProvider, config.tasks, config))
+
+  // Add a route to handle the `/messages` route
+  const messageProvider = config.messages.provider.provider
+  app.use('/message/', await MessageProvider.mount(messageProvider, config.messages, config))
 
   return express().use(config.server.prefix, app)
 }

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -2,15 +2,18 @@ require('dotenv').config()
 const convict = require('convict')
 const TaskProvider = require('../tasks')
 const UserProvider = require('../users')
+const MessageProvider = require('../messages')
 const path = require('path')
 
 const rootRelativePathFormat = require('./root_relative_path_format')
-const TaskProviderFormat = require('./task_provider_format')
+const taskProviderFormat = require('./task_provider_format')
 const userProviderFormat = require('./user_provider_format')
+const messageProviderFormat = require('./message_provider_format.js')
 
 convict.addFormat(rootRelativePathFormat)
-convict.addFormat(TaskProviderFormat)
+convict.addFormat(taskProviderFormat)
 convict.addFormat(userProviderFormat)
+convict.addFormat(messageProviderFormat)
 
 function createConfig () {
   const config = convict({
@@ -82,7 +85,7 @@ function createConfig () {
         provider: {
           doc: `
         The name of the task provider service to be used for the API.
-        Use one of: ${TaskProviderFormat.values.join(', ')}
+        Use one of: ${taskProviderFormat.values.join(', ')}
       `,
           format: 'tasks-provider',
           default: new TaskProvider()
@@ -100,6 +103,36 @@ function createConfig () {
         config: {
           doc: `
         The configuration data specific to the TaskProvider. 
+        For example, this may be used to configure API keys
+      `,
+          format: '*',
+          default: {}
+        }
+      }
+    },
+    messages: {
+      provider: {
+        provider: {
+          doc: `
+        The name of the task provider service to be used for the API.
+        Use one of: ${messageProviderFormat.values.join(', ')}
+      `,
+          format: 'message-provider',
+          default: new MessageProvider()
+        },
+        prefix: {
+          doc: `
+        The prefix where additional provider endpoints will be mounted.
+        If provider.init() returns an express.Router(), then it will be
+        mounted at /messages/provider. This may be used for setting up
+        provider specific endpoints or Oauth callbacks, etc.
+      `,
+          format: 'root-relative-path',
+          default: '/messages/provider'
+        },
+        config: {
+          doc: `
+        The configuration data specific to the MessageProvider. 
         For example, this may be used to configure API keys
       `,
           format: '*',

--- a/src/config/message_provider_format.js
+++ b/src/config/message_provider_format.js
@@ -1,0 +1,41 @@
+const MessageProvider = require('../messages')
+
+const MessageProviders = {
+  none: '../messages'
+}
+
+const values = Object.keys(MessageProviders)
+
+module.exports = {
+  name: 'message-provider',
+  values,
+  validate (val) {
+    if (!(val instanceof MessageProvider)) {
+      throw new Error('must be an instance of a MessageProvider class')
+    }
+  },
+  coerce (val) {
+    if (!val) {
+      return new MessageProvider()
+    }
+
+    // See https://stackoverflow.com/questions/18939192/how-to-test-if-b-is-a-subclass-of-a-in-javascript-node
+    if (val.prototype instanceof MessageProvider || val === MessageProvider) {
+      return val
+    }
+
+    if (typeof val !== 'string' || !values.includes(val)) {
+      throw new Error(
+        `${JSON.stringify(val, undefined, 2)} is not a valid message-provider format. ` +
+        `Must be one of: ${values.join(', ')}`
+      )
+    }
+
+    const MessageProviderClass = require(MessageProviders[val])
+    if (!(MessageProviderClass.prototype instanceof MessageProvider) && MessageProviderClass !== MessageProvider) {
+      throw new Error(`${JSON.stringify(MessageProviderClass, undefined, 2)} loaded from ${MessageProviders[val]} (${val}) is not a valid message provider constructor`)
+    }
+
+    return new MessageProviderClass()
+  }
+}

--- a/src/messages/index.js
+++ b/src/messages/index.js
@@ -1,0 +1,83 @@
+const express = require('express')
+// const logError = require('../logging/log_error')
+
+/**
+ * An abstract class which describes a way to send messages to users. For example, this might be used to configure a email sender, or to connect to a twillio API for sending SMS messages
+ *
+ * @template C a type describing the configuration object this message provider will create from its `convictConfig` function
+ */
+class MessageProvider {
+  /**
+   * This function will be called inside ./src/config/message_provider_format.js
+   * to provide configuration for the provider
+   *
+   * @returns { import("convict").Config<C> }
+   */
+  convictConfig () { return undefined }
+
+  /**
+   * Initialize to the provider service.
+   * This function may not need to do anything, but it can be used to setup one time authentication
+   * or to setup webhooks.
+   *
+   * Note that this function is marked as async, which means that you may use async calls when
+   * performing the authentication flow.
+   *
+   * @param { C } config the provider configuration, as defined by convictConfig
+   * @param { import("../config/index").Config } appConfig the application configuration. See config/index.js for full schema
+   * @returns { void | import("express").Router | PromiseLike<void | import("express").Router> } An express router which may be used to create provider specific endpoints for the api
+   */
+  init (config, appConfig) { }
+
+  /**
+   * Send a message to some users.
+   *
+   * This function attempts to send a message to the users in the `to` parameter. If the provider is not able to send the message
+   * to a user for any reason, it may throw an error, but it is not required to. The provider may also return any number of users
+   * to whom the message has been sent successfully. Note that the returned set of users may include users who were never
+   * included in the `to` parameter. Examples of such users might be administrators or supervisors who wish to be notified when
+   * a message has been sent to a particular user.
+   *
+   * This provider will use the options.message and options.title parameters to construct a message for each user. The message will include
+   * at least the text in options.message and options.title but may also include additional information and formatting at the discression of
+   * the provider implementations.
+   *
+   * @param { string[] } options.to      the ids of the users who the message will be sent to.
+   * @param { string =}  options.title   the title of the message that will be sent to the users
+   * @param { string =}  options.message the message to send to the user
+   * @returns { AsyncGenerator<string> | Generator<string> | AsyncIterable<string> | Iterable<string> } the user ids to which the message was successfully
+   * sent. If an id is present in this list, then the message has been sent. However, if an id is not present in this list, the message may or may not have
+   * been sent. Also note that a message being sent does not mean that the user has actually read the message yet.
+   **/
+  send (options) { }
+}
+
+module.exports = MessageProvider
+
+/**
+*
+* @param {MessageProvider<any>} messageProvider a user provider
+* @param { import("../config/index").Config["message"] } providerConfig the user provider configuration. See config/index.js for full schema
+* @param { import("../config/index").Config } config the application configuration. See config/index.js for full schema
+* @returns {Promise<express.Router>}
+*/
+async function mount (messageProvider, providerConfig, config) {
+  const router = express.Router()
+  router.use(express.json())
+
+  if (messageProvider) {
+    const messageProviderConfig = messageProvider.convictConfig()
+    if (messageProviderConfig) {
+      messageProviderConfig.load(providerConfig.provider.config)
+    }
+
+    const messageProviderRoute = await messageProvider.init(messageProviderConfig && messageProviderConfig.getProperties(), config)
+    if (messageProviderRoute) {
+      router.use(providerConfig.provider.prefix, messageProviderRoute)
+    }
+  }
+
+  return router
+}
+
+module.exports.mount = mount

--- a/src/messages/memory_provider.js
+++ b/src/messages/memory_provider.js
@@ -1,0 +1,21 @@
+const MessageProvider = require('.')
+
+class MemoryProvider extends MessageProvider {
+  constructor () {
+    super()
+    this.messages = {}
+  }
+
+  * send ({ to, ...content }) {
+    for (const user of to) {
+      if (user in this.messages) {
+        this.messages[user].push(content)
+      } else {
+        this.messages[user] = [content]
+      }
+      yield user
+    }
+  }
+}
+
+module.exports = MemoryProvider

--- a/src/tasks/index.js
+++ b/src/tasks/index.js
@@ -81,21 +81,6 @@ class TaskProvider {
    * @returns { AsyncGenerator<T> | Generator<T> | AsyncIterable<T> | Iterable<T> }
    */
   getTasks () { return [] }
-
-  /**
-   * Retrieve a listing of tasks from the service.
-   *
-   * This function does not accept any parameters.
-   * If you want to configure its behaviour, you should configure the object that contains it instead.
-   *
-   * Note that this function is an async generator. This means that you may use asynchronous calls inside it.
-   * Additionally, because it is a generator function, you use a yield statement instead of a return statement.
-   * this is meant to accommodate APIs that paginate their results.
-   *
-   * TODO: do we want to allow passing queries, such as "tasks due within X days" here?
-   * @returns { AsyncGenerator<T> | Generator<T> | AsyncIterable<T> | Iterable<T> }
-   */
-  getTask () { return [] }
 }
 
 module.exports = TaskProvider

--- a/src/tasks/index.js
+++ b/src/tasks/index.js
@@ -81,6 +81,21 @@ class TaskProvider {
    * @returns { AsyncGenerator<T> | Generator<T> | AsyncIterable<T> | Iterable<T> }
    */
   getTasks () { return [] }
+
+  /**
+   * Retrieve a listing of tasks from the service.
+   *
+   * This function does not accept any parameters.
+   * If you want to configure its behaviour, you should configure the object that contains it instead.
+   *
+   * Note that this function is an async generator. This means that you may use asynchronous calls inside it.
+   * Additionally, because it is a generator function, you use a yield statement instead of a return statement.
+   * this is meant to accommodate APIs that paginate their results.
+   *
+   * TODO: do we want to allow passing queries, such as "tasks due within X days" here?
+   * @returns { AsyncGenerator<T> | Generator<T> | AsyncIterable<T> | Iterable<T> }
+   */
+  getTask () { return [] }
 }
 
 module.exports = TaskProvider

--- a/src/users/memory_provider.js
+++ b/src/users/memory_provider.js
@@ -20,6 +20,10 @@ class MemoryUser extends UserProvider.User {
   doesClaimTask (taskId) {
     return this.claimedTasks.has(taskId)
   }
+
+  getTasks () {
+    return this.claimedTasks
+  }
 }
 
 /**


### PR DESCRIPTION
Adds MessageProvider, which can be used to represent a 3rd party service
which handles sending messages to users, such as an IMAP server or a
Twillio account.

Adds the POST /users/:id/report route. When a POST request is made
against this route, the app will attempt to send a message to the user
given by :id.

Also adds various minor improvements to other areas of the app to
implement to POST /users/:id/report route and tests.

TODO: make the contents of reports configurable