### PR TITLE
Small touch-ups to improve dev experience when running the server

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,8 +1,12 @@
 {
+  "users": {
+    "provider": {
+      "provider": "memory"
+    }
+  },
   "tasks": {
     "provider": { 
-      "prefix": "/provider",
-      "provider": "none"
+      "provider": "memory"
     }
   }
 }

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -57,7 +57,7 @@ function createConfig () {
         provider specific endpoints or Oauth callbacks, etc.
       `,
           format: 'root-relative-path',
-          default: '/users/provider'
+          default: '/provider'
         },
         provider: {
           doc: `
@@ -95,7 +95,7 @@ function createConfig () {
         provider specific endpoints or Oauth callbacks, etc.
       `,
           format: 'root-relative-path',
-          default: '/tasks/provider'
+          default: '/provider'
         },
         config: {
           doc: `


### PR DESCRIPTION
1. Change default task provider route from `/tasks/tasks/provider` to `/tasks/provider`
2. Change default user provider route from `/users/users/provider` to `/users/provider`
3. Make "memory" the default providers when no config is provided