### PR TITLE
CORS Configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeforlansing/cityzen-server",
-  "version": "0.0.1-alpha.7",
+  "version": "0.0.1-alpha.8",
   "main": "index.js",
   "scripts": {
     "start": "node index.js",

--- a/src/app.js
+++ b/src/app.js
@@ -20,6 +20,18 @@ async function app (config) {
   // practices
   app.use(helmet())
 
+  // Add CORS headers to allow server and client to communicate
+  app.use(function (req, res, next) {
+    config.server.corsAllowedOrigins.forEach(allowedOrigin => {
+      res.header('Access-Control-Allow-Origin', allowedOrigin)
+    })
+    res.header(
+      'Access-Control-Allow-Headers',
+      'Origin, X-Requested-With, Content-Type, Accept'
+    )
+    next()
+  })
+
   // Setup the routes (otherwise known as API endpoints, REST URLS, etc) for
   // our server.
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -6,11 +6,13 @@ const MessageProvider = require('../messages')
 const path = require('path')
 
 const rootRelativePathFormat = require('./root_relative_path_format')
+const stringListFormat = require('./string_list_format')
 const taskProviderFormat = require('./task_provider_format')
 const userProviderFormat = require('./user_provider_format')
 const messageProviderFormat = require('./message_provider_format.js')
 
 convict.addFormat(rootRelativePathFormat)
+convict.addFormat(stringListFormat)
 convict.addFormat(taskProviderFormat)
 convict.addFormat(userProviderFormat)
 convict.addFormat(messageProviderFormat)
@@ -48,6 +50,16 @@ function createConfig () {
         `,
         format: 'root-relative-path',
         default: '/'
+      },
+      corsAllowedOrigins: {
+        doc: `
+          A list of values the server will provide in Access-Control-Allow-Origin
+          headers. This allows the client to be hosted on a different domain
+          from the API while still allowing communication between the two.
+        `,
+        format: 'string-list',
+        default: [],
+        env: 'CORS_ALLOWED_ORIGINS'
       }
     },
     users: {

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -24,9 +24,9 @@ function createConfig () {
     },
     config: {
       doc: `
-    The name of a config file in the 'config' directory.
-    e.g. 'default.json'
-  `,
+        The name of a config file in the 'config' directory.
+        e.g. 'default.json'
+      `,
       format: String,
       default: 'default.json',
       arg: 'config'
@@ -34,18 +34,18 @@ function createConfig () {
     server: {
       port: {
         doc: `
-      The port to be used when the server starts running.
-    `,
+          The port to be used when the server starts running.
+        `,
         format: 'port',
         default: 3000,
         env: 'PORT'
       },
       prefix: {
         doc: `
-      The API path used to get tasks, so for example if you wanted
-      to get a listing of all the tasks the application knows about,
-      it would be at /tasks.
-    `,
+          The API path used to get tasks, so for example if you wanted
+          to get a listing of all the tasks the application knows about,
+          it would be at /tasks.
+        `,
         format: 'root-relative-path',
         default: '/'
       }
@@ -54,27 +54,27 @@ function createConfig () {
       provider: {
         prefix: {
           doc: `
-        The prefix where additional endpoints for a user provider will be mounted.
-        If userProvider.init() returns an express.Router(), then it will be
-        mounted at /users/provider. This may be used for setting up
-        provider specific endpoints or Oauth callbacks, etc.
-      `,
+            The prefix where additional endpoints for a user provider will be mounted.
+            If userProvider.init() returns an express.Router(), then it will be
+            mounted at /users/provider. This may be used for setting up
+            provider specific endpoints or Oauth callbacks, etc.
+          `,
           format: 'root-relative-path',
           default: '/provider'
         },
         provider: {
           doc: `
-          The name of the user provider to be used for this service. 
-          Use one of: ${userProviderFormat.values.join(', ')}
+            The name of the user provider to be used for this service. 
+            Use one of: ${userProviderFormat.values.join(', ')}
           `,
           format: 'user-provider',
           default: new UserProvider()
         },
         config: {
           doc: `
-        The configuration data specific to the userProvider. 
-        For example, this may be used to configure API keys
-      `,
+            The configuration data specific to the userProvider. 
+            For example, this may be used to configure API keys
+          `,
           format: '*',
           default: {}
         }
@@ -84,27 +84,27 @@ function createConfig () {
       provider: {
         provider: {
           doc: `
-        The name of the task provider service to be used for the API.
-        Use one of: ${taskProviderFormat.values.join(', ')}
-      `,
+            The name of the task provider service to be used for the API.
+            Use one of: ${taskProviderFormat.values.join(', ')}
+          `,
           format: 'tasks-provider',
           default: new TaskProvider()
         },
         prefix: {
           doc: `
-        The prefix where additional provider endpoints will be mounted.
-        If provider.init() returns an express.Router(), then it will be
-        mounted at /tasks/provider. This may be used for setting up
-        provider specific endpoints or Oauth callbacks, etc.
-      `,
+            The prefix where additional provider endpoints will be mounted.
+            If provider.init() returns an express.Router(), then it will be
+            mounted at /tasks/provider. This may be used for setting up
+            provider specific endpoints or Oauth callbacks, etc.
+          `,
           format: 'root-relative-path',
           default: '/provider'
         },
         config: {
           doc: `
-        The configuration data specific to the TaskProvider. 
-        For example, this may be used to configure API keys
-      `,
+            The configuration data specific to the TaskProvider. 
+            For example, this may be used to configure API keys
+          `,
           format: '*',
           default: {}
         }
@@ -114,27 +114,27 @@ function createConfig () {
       provider: {
         provider: {
           doc: `
-        The name of the task provider service to be used for the API.
-        Use one of: ${messageProviderFormat.values.join(', ')}
-      `,
+            The name of the task provider service to be used for the API.
+            Use one of: ${messageProviderFormat.values.join(', ')}
+          `,
           format: 'message-provider',
           default: new MessageProvider()
         },
         prefix: {
           doc: `
-        The prefix where additional provider endpoints will be mounted.
-        If provider.init() returns an express.Router(), then it will be
-        mounted at /messages/provider. This may be used for setting up
-        provider specific endpoints or Oauth callbacks, etc.
-      `,
+            The prefix where additional provider endpoints will be mounted.
+            If provider.init() returns an express.Router(), then it will be
+            mounted at /messages/provider. This may be used for setting up
+            provider specific endpoints or Oauth callbacks, etc.
+          `,
           format: 'root-relative-path',
           default: '/messages/provider'
         },
         config: {
           doc: `
-        The configuration data specific to the MessageProvider. 
-        For example, this may be used to configure API keys
-      `,
+            The configuration data specific to the MessageProvider. 
+            For example, this may be used to configure API keys
+          `,
           format: '*',
           default: {}
         }

--- a/src/config/string_list_format.js
+++ b/src/config/string_list_format.js
@@ -1,0 +1,17 @@
+
+module.exports = {
+  name: 'string-list',
+  validate (val) {
+    if (!(val instanceof Array)) {
+      throw new Error('must be an Array')
+    }
+    val.forEach(item => {
+      if (typeof item !== 'string') {
+        throw new Error('every value in list must be a string')
+      }
+    })
+  },
+  coerce (val) {
+    return val ? val.split(',') : []
+  }
+}

--- a/tests/config/string_list_format.test.js
+++ b/tests/config/string_list_format.test.js
@@ -1,0 +1,37 @@
+const format = require('../../src/config/string_list_format')
+
+describe('Test that string lists can be configured', () => {
+  test('has name', () => {
+    expect(format.name).toBe('string-list')
+  })
+
+  test('validate works', () => {
+    // happy path
+    expect(() => format.validate([])).not.toThrow()
+    expect(() => format.validate(['a'])).not.toThrow()
+    expect(() => format.validate(['a', 'b'])).not.toThrow()
+    expect(() => format.validate(['a', 'b', 'c'])).not.toThrow()
+
+    // rejects anything that's not a TaskProvider
+    expect(() => format.validate()).toThrow()
+    expect(() => format.validate({})).toThrow()
+    expect(() => format.validate([1234])).toThrow()
+    expect(() => format.validate(123)).toThrow()
+    expect(() => format.validate(null)).toThrow()
+    expect(() => format.validate(undefined)).toThrow()
+  })
+
+  test('coerce works', () => {
+    // converts valid values
+    expect(format.coerce('')).toEqual([])
+    expect(format.coerce('a')).toEqual(['a'])
+    expect(format.coerce('a,b')).toEqual(['a', 'b'])
+    expect(format.coerce('a,b,c')).toEqual(['a', 'b', 'c'])
+
+    // falsy values interpreted as empty array
+    expect(format.coerce(null)).toEqual([])
+    expect(format.coerce(undefined)).toEqual([])
+    expect(format.coerce(false)).toEqual([])
+    expect(format.coerce(0)).toEqual([])
+  })
+})


### PR DESCRIPTION
Adds `CORS_ALLOWED_ORIGINS` env. var. to configure one or more `Access-Control-Allow-Origin` header values to all responses.

To run the server and client in dev successfully, add the following line to `.env`:

```
CORS_ALLOWED_ORIGINS=http://localhost:8080
```