### PR TITLE
Fix a minor syntax error

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -37,7 +37,7 @@ jobs:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
           draft: false
-          prerelease: ${{ contains(github.ref, "-") }}
+          prerelease: ${{ contains(github.ref, '-') }}
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
 


### PR DESCRIPTION
Github Actions workflows do now allow double quoted strings - only single quoted strings are allowed: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#literals

No idea how this was working previously - maybe I just forgot to test it?